### PR TITLE
Fix bug from issue #18

### DIFF
--- a/mobile/flutter_app/lib/pages/deliveries_screen.dart
+++ b/mobile/flutter_app/lib/pages/deliveries_screen.dart
@@ -101,7 +101,8 @@ class _DeliveriesScreenState extends State<DeliveriesScreen> {
             return Text('loading...');
           default:
             if (snapshot.hasError) {
-              return Text('Error: ${snapshot.error}');
+              print('Error: ${snapshot.error}');
+              return Text('Error: Unable to load list of packages.');
             } else {
               return createListView(context, snapshot);
             }


### PR DESCRIPTION
Fixes issue #18 
Prints actual error to terminal. Might need to implement a formal logging method later.
User-facing error: "Error: Unable to load list of packages."