### PR TITLE
Auto refresh after adding/deleting a package + refresh button

### DIFF
--- a/mobile/flutter_app/lib/pages/deliveries_screen.dart
+++ b/mobile/flutter_app/lib/pages/deliveries_screen.dart
@@ -47,6 +47,14 @@ class _DeliveriesScreenState extends State<DeliveriesScreen> {
     packages = fetchPackages();
   }
 
+  // Refresh package list after a package is added/deleted or when user taps on
+  // refresh button.
+  void refreshPackageList() {
+    setState(() {
+      packages = fetchPackages();
+    });
+  }
+
   Future<List<Package>> fetchPackages() async {
     List<Package> fetchedPackages = [];
 
@@ -83,7 +91,7 @@ class _DeliveriesScreenState extends State<DeliveriesScreen> {
         return Dialog(
           child: Container(
             height: 330,
-            child: AddPackageForm()
+            child: AddPackageForm(refreshPackageList)
           )
         );
       }
@@ -104,7 +112,7 @@ class _DeliveriesScreenState extends State<DeliveriesScreen> {
               print('Error: ${snapshot.error}');
               return Text('Error: Unable to load list of packages.');
             } else {
-              return createListView(context, snapshot);
+              return createListView(context, snapshot, refreshPackageList);
             }
         }
       },
@@ -121,7 +129,7 @@ class _DeliveriesScreenState extends State<DeliveriesScreen> {
   }
 }
 
-Widget createListView(BuildContext context, AsyncSnapshot snapshot) {
+Widget createListView(BuildContext context, AsyncSnapshot snapshot, Function refreshPackageList) {
   List<Package> values = snapshot.data;
   return MediaQuery.removePadding(
     context: context,
@@ -132,7 +140,7 @@ Widget createListView(BuildContext context, AsyncSnapshot snapshot) {
         return Padding(
           padding: const EdgeInsets.fromLTRB(25, 0, 25, 0),
           child: PackageStatusCard(values[index].itemName, values[index].merchant,
-              values[index].status, values[index].trackingNum),
+              values[index].status, values[index].trackingNum, refreshPackageList),
         );
       },
     )

--- a/mobile/flutter_app/lib/pages/deliveries_screen.dart
+++ b/mobile/flutter_app/lib/pages/deliveries_screen.dart
@@ -121,7 +121,7 @@ class _DeliveriesScreenState extends State<DeliveriesScreen> {
       children: [
         Container(
           padding: const EdgeInsets.only(top: 25, right: 25, left: 25),
-          child: DeliveriesScreenHeader(addDeliveryItemHandler),
+          child: DeliveriesScreenHeader(addDeliveryItemHandler, refreshPackageList),
         ),
         Expanded(child: futureBuilder)
       ],

--- a/mobile/flutter_app/lib/widgets/deliveries_screen/add_package_form.dart
+++ b/mobile/flutter_app/lib/widgets/deliveries_screen/add_package_form.dart
@@ -7,7 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 
 class AddPackageForm extends StatefulWidget {
-	const AddPackageForm({ Key? key }) : super(key: key);
+	final Function refreshPackageList;
+	const AddPackageForm(this.refreshPackageList, { Key? key }) : super(key: key);
 
 	@override
 	AddPackageFormState createState() {
@@ -33,7 +34,7 @@ class AddPackageFormState extends State<AddPackageForm> {
 		});
 	}
 
-	void addPackage() async {
+	void addPackage(Function refreshPackageList) async {
 		bool success = false;
 
 		String? userId = FirebaseAuth.instance.currentUser?.uid;
@@ -54,6 +55,7 @@ class AddPackageFormState extends State<AddPackageForm> {
 
 		if (response.statusCode == 200) {
 			success = true;
+			refreshPackageList();
 		}
 
 		apiResultType = success ? '' : 'Error';
@@ -134,7 +136,7 @@ class AddPackageFormState extends State<AddPackageForm> {
 						// Validate returns true if the form is valid, or false otherwise.
 							if (_formKey.currentState!.validate()) {
 								_formKey.currentState?.save();
-								addPackage();
+								addPackage(widget.refreshPackageList);
 							}
 						},
 						child: const Text('Add'),

--- a/mobile/flutter_app/lib/widgets/deliveries_screen/deliveries_screen_header.dart
+++ b/mobile/flutter_app/lib/widgets/deliveries_screen/deliveries_screen_header.dart
@@ -5,9 +5,12 @@ import 'package_status_card.dart';
 
 
 class DeliveriesScreenHeader extends StatelessWidget {
-	const DeliveriesScreenHeader(this.addDeliveryItemHandler, {Key? key}) : super(key: key);
-
 	final Function addDeliveryItemHandler;
+	final Function refreshPackageList;
+
+	const DeliveriesScreenHeader(
+		this.addDeliveryItemHandler, this.refreshPackageList, {Key? key}
+	) : super(key: key);
 
 	final TextStyle textStyle = const TextStyle(
 		color: const Color(0xff446491),
@@ -21,36 +24,60 @@ class DeliveriesScreenHeader extends StatelessWidget {
 
 	@override
 	Widget build(BuildContext context) {
-		return SizedBox(
+
+		Text deliveriesScreenTitle = Text(
+			'Deliveries',
+			style: textStyle
+		);
+
+		GestureDetector addPackageButton = GestureDetector(
+			onTap: () {
+				addDeliveryItem(context);
+			},
+			child: Icon(
+				Icons.add_circle,
+				color: Color(0xff446491),
+				size: 23.25
+			)
+		);
+
+		GestureDetector refreshButton = GestureDetector(
+			onTap: () {
+				refreshPackageList();
+			},
+			child: Icon(
+				Icons.refresh,
+				color: Color(0xff446491),
+				size: 23.25
+			),
+		);
+
+
+		SizedBox header = SizedBox(
 			height: 28,
 			width: double.infinity,
 			child: Stack(
 				children: [
 					Positioned(
 						top: 0,
-						right: 0,
-						child: GestureDetector(
-							onTap: () {
-								addDeliveryItem(context);
-							},
-							child: Icon(
-								Icons.add_circle,
-								color: Color(0xff446491),
-								size: 23.25
-							)
-						),
+						left: 0,
+						child: refreshButton
 					),
 					Positioned(
 						top: 0,
-						left: 0,
-						child: Text(
-							'Deliveries',
-							style: textStyle
-						)
+						left: 40,
+						child: deliveriesScreenTitle
+					),
+					Positioned(
+						top: 0,
+						right: 0,
+						child: addPackageButton,
 					)
 				]
 			)
 		);
+
+		return header;
 	}
 
 }

--- a/mobile/flutter_app/lib/widgets/deliveries_screen/package_status_card.dart
+++ b/mobile/flutter_app/lib/widgets/deliveries_screen/package_status_card.dart
@@ -9,12 +9,14 @@ class PackageStatusCard extends StatefulWidget {
 	final String merchant;
 	final String status;
 	final String trackingNumber;
+	final Function refreshPackageList;
 
 	const PackageStatusCard(
 		this.itemName,
 		this.merchant,
 		this.status,
 		this.trackingNumber,
+		this.refreshPackageList,
 		{Key? key}
 	) : super(key: key);
 
@@ -51,14 +53,14 @@ class _PackageStatusCardState extends State<PackageStatusCard> {
 		});
 	}
 
-	void _showDeletePackageDialog(context, trackingNumber) {
+	void _showDeletePackageDialog(context, trackingNumber, refreshPackageList) {
     showDialog(
       context: context,
       builder: (BuildContext context) {
         return Dialog(
           child: Container(
             height: 100,
-            child: DeletePackageForm(trackingNumber)
+            child: DeletePackageForm(trackingNumber, refreshPackageList)
           )
         );
       }
@@ -114,7 +116,7 @@ class _PackageStatusCardState extends State<PackageStatusCard> {
 			deleteButton = GestureDetector(
 				onTap: () {
 					showDeleteButtonHandler(false);
-					_showDeletePackageDialog(context, widget.trackingNumber);
+					_showDeletePackageDialog(context, widget.trackingNumber, widget.refreshPackageList);
 				},
 				child: Container(
 					decoration: BoxDecoration(


### PR DESCRIPTION
Issue #21 fix

- Package list automatically refreshes after a package is successfully added/removed
- Successful adding/removal of packages no longer shows an unnecessary api result box
- An error box will show if the adding/removal failed
-
- A refresh button is added to the left of the deliveries screen title
- Tapping on it will refresh the package list
<img width="356" alt="image" src="https://user-images.githubusercontent.com/56775136/155889683-9bf76251-48aa-4169-b7c5-e50003991223.png">
