### PR TITLE
Dynamic refresh of package status cards list

### DIFF
--- a/mobile/flutter_app/lib/main.dart
+++ b/mobile/flutter_app/lib/main.dart
@@ -4,11 +4,12 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:provider/provider.dart';
 
-import './utils/authentication_service.dart';
+import '/models/package_list_model.dart';
+import '/utils/authentication_service.dart';
 
 ///********** UI Import **********///
-import "./pages/splash.dart";
-import "./utils/colors.dart";
+import "/pages/splash.dart";
+import "/utils/colors.dart";
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -30,6 +31,9 @@ class MyApp extends StatelessWidget {
           create: (context) =>
               context.read<AuthenticationService>().authStateChanges,
           initialData: null,
+        ),
+        ChangeNotifierProvider(
+          create: (context) => PackageListModel()
         )
       ],
       child: MaterialApp(

--- a/mobile/flutter_app/lib/models/package.dart
+++ b/mobile/flutter_app/lib/models/package.dart
@@ -1,0 +1,9 @@
+
+class Package {
+  final String itemName;
+  final String merchant;
+  final String status;
+  final String trackingNum;
+
+  Package(this.itemName, this.merchant, this.status, this.trackingNum);
+}

--- a/mobile/flutter_app/lib/models/package_list_model.dart
+++ b/mobile/flutter_app/lib/models/package_list_model.dart
@@ -1,0 +1,118 @@
+// Reference: https://docs.flutter.dev/development/data-and-backend/state-mgmt/simple
+
+import 'dart:collection';
+import 'dart:convert';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:provider/provider.dart';
+
+import '/models/package.dart';
+
+
+class PackageListModel extends ChangeNotifier {
+	final List<Package> _packageList = [];
+
+	// initialize package list by pulling from backend
+
+	// packageList is not modifiable but updates when _packageList updates
+	UnmodifiableListView<Package> get packageList => UnmodifiableListView(_packageList);
+
+	PackageListModel() {
+		this.loadList();
+	}
+
+	// TODO: catch exception
+	Future<void> loadList() async {
+		_packageList.clear();
+
+    String? userId = FirebaseAuth.instance.currentUser?.uid;
+    final response = await http.get(Uri.parse(
+        'http://localhost:3000/package/all?userId=$userId'));
+
+    if (response.statusCode == 200) {
+      var responsePackages = jsonDecode(response.body)["data"];
+			// TODO: Fill in proper fields for Package
+      responsePackages.forEach((trackingNum, v) =>
+        _packageList.add(
+					Package(
+            trackingNum,
+            trackingNum,
+            v['status_description'],
+            trackingNum
+        	)
+				)
+			);
+
+			notifyListeners();
+
+    } else {
+      // If the server did not return a 200 OK response,
+      // then throw an exception.
+      throw Exception('Failed to load packages');
+    }
+	}
+
+	Future<Map> add(
+		String? itemName,
+		String? trackingNumber,
+		String? merchantName,
+		String? orderNumber
+	) async {
+
+		bool success = false;
+		String errorMsg = "";
+
+		String? userId = FirebaseAuth.instance.currentUser?.uid;
+		String uri = 'http://localhost:3000/package';
+
+		Map data = {
+			'userId': userId,
+			'trackingNumber': trackingNumber
+		};
+
+		var body = json.encode(data);
+
+		var response = await http.post(
+			Uri.parse(uri),
+      headers: {"Content-Type": "application/json"},
+      body: body
+	  );
+
+		if (response.statusCode == 200) {
+			success = true;
+			await this.loadList();
+			notifyListeners();
+		} else {
+			errorMsg = jsonDecode(response.body)["msg"];
+		}
+
+		return {
+			"success": success,
+			"errorMsg": errorMsg
+		};
+	}
+
+	// TODO: Call api and then call this fnc
+	Future<String> delete(String trackingNum) async {
+
+		bool success = false;
+
+		String? userId = FirebaseAuth.instance.currentUser?.uid;
+		String uri = 'http://localhost:3000/package?userId=${userId}&trackingNumber=${trackingNum}';
+
+		var response = await http.delete(
+			Uri.parse(uri)
+	  );
+
+		if (response.statusCode == 200) {
+			success = true;
+			await this.loadList();
+			notifyListeners();
+		}
+
+		String apiResult = jsonDecode(response.body)["msg"];
+
+		return success ? "" : apiResult;
+	}
+}

--- a/mobile/flutter_app/lib/widgets/deliveries_screen/deliveries_screen_header.dart
+++ b/mobile/flutter_app/lib/widgets/deliveries_screen/deliveries_screen_header.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-import '/utils/colors.dart';
 import 'package_status_card.dart';
+import '/models/package_list_model.dart';
+import '/utils/colors.dart';
 
 
 class DeliveriesScreenHeader extends StatelessWidget {
 	final Function addDeliveryItemHandler;
-	final Function refreshPackageList;
 
 	const DeliveriesScreenHeader(
-		this.addDeliveryItemHandler, this.refreshPackageList, {Key? key}
+		this.addDeliveryItemHandler, {Key? key}
 	) : super(key: key);
 
 	final TextStyle textStyle = const TextStyle(
@@ -32,7 +33,7 @@ class DeliveriesScreenHeader extends StatelessWidget {
 
 		GestureDetector addPackageButton = GestureDetector(
 			onTap: () {
-				addDeliveryItem(context);
+				addDeliveryItemHandler(context);
 			},
 			child: Icon(
 				Icons.add_circle,
@@ -43,7 +44,7 @@ class DeliveriesScreenHeader extends StatelessWidget {
 
 		GestureDetector refreshButton = GestureDetector(
 			onTap: () {
-				refreshPackageList();
+				Provider.of<PackageListModel>(context, listen: false).loadList();
 			},
 			child: Icon(
 				Icons.refresh,

--- a/mobile/flutter_app/lib/widgets/deliveries_screen/package_status_card.dart
+++ b/mobile/flutter_app/lib/widgets/deliveries_screen/package_status_card.dart
@@ -1,24 +1,14 @@
 import 'package:flutter/material.dart';
 
+import '/models/package.dart';
 import '/utils/colors.dart';
 import '/widgets/deliveries_screen/delete_package_form.dart';
 
 
 class PackageStatusCard extends StatefulWidget {
-	final String itemName;
-	final String merchant;
-	final String status;
-	final String trackingNumber;
-	final Function refreshPackageList;
+	final Package package;
 
-	const PackageStatusCard(
-		this.itemName,
-		this.merchant,
-		this.status,
-		this.trackingNumber,
-		this.refreshPackageList,
-		{Key? key}
-	) : super(key: key);
+	const PackageStatusCard(this.package, {Key? key}) : super(key: key);
 
 	@override
 	_PackageStatusCardState createState() => _PackageStatusCardState();
@@ -53,14 +43,14 @@ class _PackageStatusCardState extends State<PackageStatusCard> {
 		});
 	}
 
-	void _showDeletePackageDialog(context, trackingNumber, refreshPackageList) {
+	void _showDeletePackageDialog(context, trackingNumber) {
     showDialog(
       context: context,
       builder: (BuildContext context) {
         return Dialog(
           child: Container(
             height: 100,
-            child: DeletePackageForm(trackingNumber, refreshPackageList)
+            child: DeletePackageForm(trackingNumber)
           )
         );
       }
@@ -71,28 +61,35 @@ class _PackageStatusCardState extends State<PackageStatusCard> {
 	Widget build(BuildContext context) {
 		double screenWidth = MediaQuery.of(context).size.width;
 
+		String itemName = widget.package.itemName;
+		String merchant = widget.package.merchant;
+		String status = widget.package.status;
+		String trackingNum = widget.package.trackingNum;
+
+		status = status[0].toUpperCase() + status.substring(1);
+
 		Padding cardContent = Padding(
 			padding: EdgeInsets.only(top: 10, left: 15, bottom: 13),
 			child: Column(
 				crossAxisAlignment: CrossAxisAlignment.start,
 				children: [
 					Text(
-						"Item: ${widget.itemName}",
+						"Item: ${itemName}",
 						style: itemNameStyle
 					),
 					Spacer(),
 					Text(
-						"Merchant: ${widget.merchant}",
+						"Merchant: ${merchant}",
 						style: textStyle
 					),
 					Spacer(),
 					Text(
-						"Status: ${widget.status[0].toUpperCase()}${widget.status.substring(1)}",
+						"Status: ${status}",
 						style: textStyle
 					),
 					Spacer(),
 					Text(
-						"Tracking: ${widget.trackingNumber}",
+						"Tracking #: ${trackingNum}",
 						style: textStyle
 					)
 				]
@@ -116,7 +113,7 @@ class _PackageStatusCardState extends State<PackageStatusCard> {
 			deleteButton = GestureDetector(
 				onTap: () {
 					showDeleteButtonHandler(false);
-					_showDeletePackageDialog(context, widget.trackingNumber, widget.refreshPackageList);
+					_showDeletePackageDialog(context, trackingNum);
 				},
 				child: Container(
 					decoration: BoxDecoration(


### PR DESCRIPTION
Resolves Issue #22

- Created PackageListModel
- packageList sits at the top of the widget tree so switching between screens won't cause the app to make an api call to get the package list every time the app switches back to deliveries screen

- Also rewrote a lot of code so that it's more organized
- api calls related to packages are all within PackageListModel class